### PR TITLE
Fixed header starting on wrong side of paper

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -93,8 +93,8 @@
 
 \fancypagestyle{unilustyle}{
     \fancyhead[LO]{\emph{\slshape{\nouppercase{\leftmark}}}}
-    \fancyhead[RE]{\emph{\slshape{\nouppercase{\rightmark}}}}
-    \fancyhead[LE,RO]{ }
+    \fancyhead[LE]{\emph{\slshape{\nouppercase{\rightmark}}}}
+    \fancyhead[RE,RO]{ }
     \fancyfoot[RE,LO]{\thepage}
     \fancyfoot[LE,RO]{}
     \fancyfoot[CE,CO]{ }


### PR DESCRIPTION
@lothritz This is a fix to the issue you reported having with the alignment of the headers. From my reading, the behavior that you noticed is normal and expected. That is because the thesis is expected to be printed as a double-sided document. Therefore, changing the position of the header makes it easy to read - on paper.

My modification is motivated by style configurations following a certain convention whereby you use selectors to specify what should be there. You have, for instance, **R** (Right), **L** (Left), **O** (Odd) and **E** (Even). Then the old configuration, for instance, stated that on the right side of even pages, there should be the right mark (only the chapter number and title) which you will notice is different from the left mark (longer version). Then on the left side of even pages and right side of the odd ones, nothing is out there. And that leads to the output you had.

Consequently, my change makes the right mark come to the left on even pages and nothing on the right side. Again, I believe that the initial output was desired but anyway, I hope this helps you play around and get the template to the desired outcome. 

This page provides some context about the header and footers. 
https://www.overleaf.com/learn/latex/Headers_and_footers